### PR TITLE
ci: add retries for cache workflow curl calls

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -19,26 +19,26 @@ jobs:
 
       - name: Fetch CoinGecko markets
         run: |
-          curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=bitcoin,ethereum,solana,binancecoin&precision=full" > data/cg.json
+          curl -s --retry 3 --fail "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=bitcoin,ethereum,solana,binancecoin&precision=full" > data/cg.json || true
 
       - name: Fetch DeFiLlama chain stats
         run: |
-          curl -s "https://api.llama.fi/overview/tvl/bitcoin?period=now"    > data/btc_tvl.json
-          curl -s "https://api.llama.fi/overview/activeAddresses/bitcoin?period=24h"  > data/btc_dau.json || true
-          curl -s "https://api.llama.fi/overview/transactions/bitcoin?period=24h"     > data/btc_tx.json  || true
-          curl -s "https://api.llama.fi/overview/fees/bitcoin?period=24h"             > data/btc_fees.json
-          curl -s "https://api.llama.fi/overview/tvl/ethereum?period=now"  > data/eth_tvl.json
-          curl -s "https://api.llama.fi/overview/activeAddresses/ethereum?period=24h" > data/eth_dau.json
-          curl -s "https://api.llama.fi/overview/transactions/ethereum?period=24h"    > data/eth_tx.json
-          curl -s "https://api.llama.fi/overview/fees/ethereum?period=24h"            > data/eth_fees.json
-          curl -s "https://api.llama.fi/overview/tvl/solana?period=now"    > data/sol_tvl.json
-          curl -s "https://api.llama.fi/overview/activeAddresses/solana?period=24h"   > data/sol_dau.json
-          curl -s "https://api.llama.fi/overview/transactions/solana?period=24h"      > data/sol_tx.json
-          curl -s "https://api.llama.fi/overview/fees/solana?period=24h"              > data/sol_fees.json
-          curl -s "https://api.llama.fi/overview/tvl/bsc?period=now"       > data/bnb_tvl.json
-          curl -s "https://api.llama.fi/overview/activeAddresses/bsc?period=24h"      > data/bnb_dau.json
-          curl -s "https://api.llama.fi/overview/transactions/bsc?period=24h"         > data/bnb_tx.json
-          curl -s "https://api.llama.fi/overview/fees/bsc?period=24h"                 > data/bnb_fees.json
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/tvl/bitcoin?period=now"    > data/btc_tvl.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/activeAddresses/bitcoin?period=24h"  > data/btc_dau.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/transactions/bitcoin?period=24h"     > data/btc_tx.json  || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/fees/bitcoin?period=24h"             > data/btc_fees.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/tvl/ethereum?period=now"  > data/eth_tvl.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/activeAddresses/ethereum?period=24h" > data/eth_dau.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/transactions/ethereum?period=24h"    > data/eth_tx.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/fees/ethereum?period=24h"            > data/eth_fees.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/tvl/solana?period=now"    > data/sol_tvl.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/activeAddresses/solana?period=24h"   > data/sol_dau.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/transactions/solana?period=24h"      > data/sol_tx.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/fees/solana?period=24h"              > data/sol_fees.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/tvl/bsc?period=now"       > data/bnb_tvl.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/activeAddresses/bsc?period=24h"      > data/bnb_dau.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/transactions/bsc?period=24h"         > data/bnb_tx.json || true
+          curl -s --retry 3 --fail "https://api.llama.fi/overview/fees/bsc?period=24h"                 > data/bnb_fees.json || true
 
       - name: Fetch NVT sources (no key)
         run: |


### PR DESCRIPTION
## Summary
- retry CoinGecko and DeFiLlama curl requests up to 3 times and ignore transient failures

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d94203de0832fba5033018b500ce0