### PR TITLE
Fix chart function call name for first metric chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@ function drawCharts(rows){
   const mk=(id,data)=>{ if(charts[id]) charts[id].destroy();
     charts[id]=new Chart(document.getElementById(id),{type:'bar',data:{labels,datasets:[{data}]},options:{plugins:{legend:{display:false}},scales:{y:{beginAtZero:true}}}});
   };
-  mmk("m1", rows.map(r => r.mcapTvl ?? 0));
+  mk("m1", rows.map(r => r.mcapTvl ?? 0));
   
   mk("m2", rows.map(r => r.mcapPerDAU ?? 0));
   mk("m3", rows.map(r => r.mcapPerTx ?? 0));


### PR DESCRIPTION
## Summary
- Ensure `drawCharts` uses `mk` for all four charts so they render correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d9688f3f0832fbc2dcbdedbf06296