### PR TITLE
Handle missing chart data with null

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,13 +169,23 @@ let charts={};
 function drawCharts(rows){
   const labels=rows.map(r=>r.sym);
   const mk=(id,data)=>{ if(charts[id]) charts[id].destroy();
-    charts[id]=new Chart(document.getElementById(id),{type:'bar',data:{labels,datasets:[{data}]},options:{plugins:{legend:{display:false}},scales:{y:{beginAtZero:true}}}});
+    charts[id]=new Chart(document.getElementById(id),{
+      type:'bar',
+      data:{labels,datasets:[{data}]},
+      options:{
+        plugins:{
+          legend:{display:false},
+          tooltip:{callbacks:{label:ctx=>ctx.parsed.y==null?`${ctx.label}：数据缺失`:`${ctx.label}：${ctx.formattedValue}`}}
+        },
+        scales:{y:{beginAtZero:true}}
+      }
+    });
   };
-  mmk("m1", rows.map(r => r.mcapTvl ?? 0));
-  
-  mk("m2", rows.map(r => r.mcapPerDAU ?? 0));
-  mk("m3", rows.map(r => r.mcapPerTx ?? 0));
-  mk("m4", rows.map(r => r.feesBpDay ?? 0));
+  mk("m1", rows.map(r => r.mcapTvl ?? null));
+
+  mk("m2", rows.map(r => r.mcapPerDAU ?? null));
+  mk("m3", rows.map(r => r.mcapPerTx ?? null));
+  mk("m4", rows.map(r => r.feesBpDay ?? null));
 }
 
 function renderKPI(sent){


### PR DESCRIPTION
## Summary
- skip plotting missing metrics by mapping to `null` instead of `0`
- show "数据缺失" in tooltips for null values

## Testing
- `node <<'NODE'
const fs=require('fs');
const vm=require('vm');
const context={
  document:{getElementById:id=>({id})},
  Chart:class{constructor(el,config){if(!context._charts)context._charts={};context._charts[el.id]={config};}destroy(){}
  }
};
context.global=context;
vm.createContext(context);
let script=fs.readFileSync('index.html','utf8').split('<script>')[1].split('</script>')[0];
script=script.replace(/document.getElementById\("refresh"\).+?load\(\);\n?/s,'');
vm.runInContext(script,context);
const rows=[{sym:'BTC',mcapTvl:10,mcapPerDAU:20,mcapPerTx:30,feesBpDay:40},{sym:'ETH',mcapTvl:null,mcapPerDAU:null,mcapPerTx:null,feesBpDay:null},{sym:'SOL',mcapTvl:5,mcapPerDAU:6,mcapPerTx:7,feesBpDay:8}];
context.drawCharts(rows);
console.log('m1 data:',context._charts['m1'].config.data.datasets[0].data);
console.log('m2 data:',context._charts['m2'].config.data.datasets[0].data);
const tooltip=context._charts['m2'].config.options.plugins.tooltip.callbacks.label;
console.log('tooltip null:',tooltip({label:'ETH',parsed:{y:null},formattedValue:'0'}));
console.log('tooltip value:',tooltip({label:'BTC',parsed:{y:20},formattedValue:'20'}));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689d968a0c08832f86e1b53507b89a34