### PR TITLE
Format chart tooltips with friendly units

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,28 @@ let charts={};
 function drawCharts(rows){
   const labels=rows.map(r=>r.sym);
   const mk=(id,data)=>{ if(charts[id]) charts[id].destroy();
-    charts[id]=new Chart(document.getElementById(id),{type:'bar',data:{labels,datasets:[{data}]},options:{plugins:{legend:{display:false}},scales:{y:{beginAtZero:true}}}});
+    charts[id]=new Chart(document.getElementById(id),{
+      type:'bar',
+      data:{labels,datasets:[{data}]},
+      options:{
+        plugins:{
+          legend:{display:false},
+          tooltip:{
+            callbacks:{
+              label:ctx=>{
+                const y=ctx.parsed.y, ay=Math.abs(y);
+                let v=y, unit="";
+                if(ay>=1e9){v=toB(y);unit="B";}
+                else if(ay>=1e6){v=toM(y);unit="M";}
+                else if(ay>=1e3){v=y/1e3;unit="K";}
+                return "$"+nf2.format(v)+unit;
+              }
+            }
+          }
+        },
+        scales:{y:{beginAtZero:true}}
+      }
+    });
   };
   mmk("m1", rows.map(r => r.mcapTvl ?? 0));
   


### PR DESCRIPTION
## Summary
- format chart tooltip labels using Intl formatter and units

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d968d2d28832fa6f089da71b937b7